### PR TITLE
Fix round-robin example.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,23 @@
 version: "2"
 
-services: 
+services:
   mynodeapp:
-    build: 
+    build:
       context: ./app
-      dockerfile: Dockerfile 
+      dockerfile: Dockerfile
     networks:
-      - mynetwork
-
-  nginx: 
-    build: 
+      mynetwork:
+        aliases:
+          - mynodeapp
+  nginx:
+    build:
       context: ./nginx
-      dockerfile: Dockerfile 
+      dockerfile: Dockerfile
     ports:
       - "80:80"
       - "443:443"
     networks:
       - mynetwork
-    links:
-      - mynodeapp
 
-  
-networks: 
+networks:
   mynetwork:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,13 +1,18 @@
-upstream nodeapp {
-  server mynodeapp:3333 fail_timeout=10s;
-}
-
 server {
   listen 80;
   server_name scale-test.com;
 
+  # Docker internal DNS
+  resolver 127.0.0.11 valid=1s;
+
   location / {
-    proxy_pass http://nodeapp/;
+    # Use a variable and no upstream for proxy_pass to force Nginx to force re-resolve
+    # (workaround for a limitation of nginx)
+    # see https://www.ruby-forum.com/topic/4407628
+
+    set $alias "mynodeapp:3333";
+    proxy_pass http://$alias/;
+
     proxy_redirect off;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -16,4 +21,3 @@ server {
   }
 
 }
-


### PR DESCRIPTION
Change Nginx conf to force reevaluation of server.
Add aliases on network docker-compose.
